### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In order to use [generator functions](https://developer.mozilla.org/en-US/docs/W
 
     ```js
     'ember-cli-babel': {
-      includePolyfills: true
+      includePolyfill: true
     }
     ```
 


### PR DESCRIPTION
Fixes example in README.md for `ember-cli-babel` config.

- [x] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

fix example in README.md for `ember-cli-babel` config
